### PR TITLE
Fix: ViewPager does not scroll after props.data changed

### DIFF
--- a/src/ViewPager.js
+++ b/src/ViewPager.js
@@ -107,6 +107,9 @@ export default class ViewPager extends PureComponent {
       this.contentContainerStyle = {
         width: nextProps.pageWidth * newDataSource.length,
       }
+
+      this.data = nextProps.data;
+      this.pageCount = this.data.length;
     }
     this.setState({
       dataSource: newDataSource,


### PR DESCRIPTION
**Reproduce step**
First, init the viewpager with only 1 item:
```
const { items } = this.state; // items = [{...}]; // only one element
<ViewPager
    ref={c => window.ViewPagerInstance = c}
    data={items}
/>
```

Then, after fetching items from API, bind new items:
```
this.setState({ items: newItemsFromAPI })
```
**Actual result**
Can not swipe between pages.

**Expected result**
Can swipe.

**Debuging**
As I can see: 
```
ViewPagerInstance.pageCount === 1; // still eq 1 after bind `data={list of 20 items}`
```
So, `_getScrollEnabled` function will return false
As a result, ScrollView > scrollEnabled was disabled:
```
<ScrollView
          ...
          scrollEnabled={this._getScrollEnabled()}
          ...
```
